### PR TITLE
Improvement: make breadcrumbs label dynamic

### DIFF
--- a/src/breadcrumbComponent.js
+++ b/src/breadcrumbComponent.js
@@ -115,7 +115,7 @@ export default {
         routeLabel = breadcrumbLabel
       }
 
-      return routeLabel
+      return typeof routeLabel === 'function' ? routeLabel.call(this, this.$route) : routeLabel
     },
 
     // Function resolves a utils object of the provided route


### PR DESCRIPTION
Breadcrumb labels can be dynamic like [vue-2-breadcrumbs](https://github.com/Scrum/vue-2-breadcrumbs)
```
meta: {
  breadcrumb: () => `foo ${1 + 1}`
}
```