### PR TITLE
Fix for parentDynamicRoutes being cleared on route change

### DIFF
--- a/src/breadcrumbComponent.js
+++ b/src/breadcrumbComponent.js
@@ -1,3 +1,5 @@
+import get from 'lodash/get'
+
 const utils = {
   isObject (checkMe) {
     return typeof checkMe === 'object'&& !Array.isArray(checkMe) && checkMe !== null
@@ -206,9 +208,9 @@ export default {
     }
   },
   watch: {
-    '$route' () {
-      // Set empty component's 'parentsDynamicRoutes' property on each route change
-      this.parentsDynamicRoutes = []
+    '$route' (newRoute) {
+      // Set or clear component's 'parentsDynamicRoutes' property on each route change
+      this.parentsDynamicRoutes = [...get(newRoute, 'meta.breadcrumb.parentsList', [])].reverse()
     }
   },
   created () {


### PR DESCRIPTION
Closes: #5

Here's a link to a reproduction: https://codesandbox.io/s/vue-template-yy32j (When you click on 'foo' in the navigation, the router will only show the `id`, while it should show the full breadcrumb with parents list).